### PR TITLE
feat: 연구실 생성 API

### DIFF
--- a/prisma/migrations/0_init/migration.sql
+++ b/prisma/migrations/0_init/migration.sql
@@ -110,7 +110,7 @@ CREATE TABLE lab_members
     joined_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     left_at   TIMESTAMPTZ,
 
-    CONSTRAINT chk_lab_member_role CHECK (role IN ('LAB_LEADER', 'MEMBER')),
+    CONSTRAINT chk_lab_member_role CHECK (role IN ('PROFESSOR', 'LAB_LEADER', 'MEMBER')),
 
     -- 같은 연구실 중복 "활성" 가입 방지
     CONSTRAINT uq_lab_members_active_user_lab UNIQUE (user_id, lab_id) DEFERRABLE INITIALLY IMMEDIATE

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,9 +5,10 @@ import { PrismaModule } from './prisma/prisma.module.js';
 import { UserModule } from './user/user.module.js';
 import { AuthModule } from './auth/auth.module.js';
 import { AuthService } from './auth/auth.service.js';
+import { LabModule } from './lab/lab.module.js';
 
 @Module({
-  imports: [PrismaModule, UserModule, AuthModule],
+  imports: [PrismaModule, UserModule, AuthModule, LabModule],
   controllers: [AppController],
   providers: [AppService, AuthService],
 })

--- a/src/lab/dto/request/create-lab.request.dto.ts
+++ b/src/lab/dto/request/create-lab.request.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsOptional, MinLength } from 'class-validator';
+
+export class CreateLabRequestDto {
+  @IsString()
+  @MinLength(2)
+  schoolName: string;
+
+  @IsOptional()
+  @IsOptional()
+  departmentName: string;
+
+  @IsString()
+  @MinLength(2)
+  labName: string;
+}

--- a/src/lab/lab.controller.spec.ts
+++ b/src/lab/lab.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LabController } from './lab.controller.js';
+
+describe('LabController', () => {
+  let controller: LabController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LabController],
+    }).compile();
+
+    controller = module.get<LabController>(LabController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/lab/lab.controller.ts
+++ b/src/lab/lab.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { LabService } from './lab.service.js';
+import { CreateLabRequestDto } from './dto/request/create-lab.request.dto.js';
+
+@Controller('lab')
+export class LabController {
+  constructor(private readonly labService: LabService) {}
+
+  @Post()
+  create(@Body() dto: CreateLabRequestDto) {
+    // TODO: @CurrentUser() 데코레이터로 실제 로그인 유저 갖고오기
+    const id = 1; // 임시
+    return this.labService.create(id, dto);
+  }
+}

--- a/src/lab/lab.error.ts
+++ b/src/lab/lab.error.ts
@@ -1,0 +1,25 @@
+import { HttpStatus } from '@nestjs/common';
+import { ErrorInfo } from '../common/exceptions/common.exception.js';
+
+export const LAB_ERRORS: Record<string, ErrorInfo> = {
+  USER_NOT_FOUND: {
+    code: 'LAB001',
+    message: '존재하지 않는 사용자.',
+    status: HttpStatus.BAD_REQUEST,
+  },
+  NOT_VERIFIED_PROFESSOR: {
+    code: 'LAB002',
+    message: '인증되지 않은 교수.',
+    status: HttpStatus.BAD_REQUEST,
+  },
+  NOT_VERIFIED_PROFESSOR_PENDING: {
+    code: 'LAB003',
+    message: '인증 대기중인 교수.',
+    status: HttpStatus.BAD_REQUEST,
+  },
+  ALREADY_IN_LAB: {
+    code: 'LAB004',
+    message: '이미 연구실에 소속된 사용자.',
+    status: HttpStatus.BAD_REQUEST,
+  },
+};

--- a/src/lab/lab.module.ts
+++ b/src/lab/lab.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { LabService } from './lab.service.js';
+import { LabController } from './lab.controller.js';
+import { PrismaModule } from '../prisma/prisma.module.js';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [LabService],
+  controllers: [LabController],
+})
+export class LabModule {}

--- a/src/lab/lab.service.spec.ts
+++ b/src/lab/lab.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LabService } from './lab.service.js';
+
+describe('LabService', () => {
+  let service: LabService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LabService],
+    }).compile();
+
+    service = module.get<LabService>(LabService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/lab/lab.service.ts
+++ b/src/lab/lab.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CommonException } from '../common/exceptions/common.exception.js';
+import { LAB_ERRORS } from './lab.error.js';
+import { CreateLabRequestDto } from './dto/request/create-lab.request.dto.js';
+
+@Injectable()
+export class LabService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(professorId: number, dto: CreateLabRequestDto) {
+    // 교수 인증 상태 확인
+    const user = await this.prisma.users.findUnique({
+      where: { id: professorId },
+    });
+
+    if (!user) {
+      throw new CommonException(LAB_ERRORS.USER_NOT_FOUND);
+    }
+
+    if (user.professor_status == 'PENDING') {
+      throw new CommonException(LAB_ERRORS.NOT_VERIFIED_PROFESSOR_PENDING);
+    }
+
+    if (user.professor_status !== 'VERIFIED') {
+      throw new CommonException(LAB_ERRORS.NOT_VERIFIED_PROFESSOR);
+    }
+
+    // 연구실 중복 소속 확인
+    const isUserExistingLab = await this.prisma.lab_members.findFirst({
+      where: { id: professorId, left_at: null },
+    });
+
+    if (isUserExistingLab) {
+      throw new CommonException(LAB_ERRORS.ALREADY_IN_LAB);
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const lab = await tx.labs.create({
+        data: {
+          name: dto.labName,
+          school_name: dto.schoolName,
+          department_name: dto.departmentName,
+          professor_id: professorId,
+        },
+      });
+
+      await tx.lab_members.create({
+        data: {
+          user_id: professorId,
+          lab_id: lab.id,
+          role: 'PROFESSOR',
+        },
+      });
+
+      return lab;
+    });
+  }
+}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #1 

---

### 🚀 어떤 기능을 구현했나요?
- 연구실 생성 API (`POST /api/lab`)
- 인증된 교수만 연구실 생성 가능
- 연구실 생성 시 교수가 자동으로 멤버로 등록


### 🔥 어떻게 해결했나요?
- `LabModule`, `LabController`, `LabService` 구조로 분리
- 트랜잭션으로 `labs` + `lab_members` 테이블 동시 생성
- 커스텀 예외 클래스(`BusinessException`) 도입하여 에러 응답 통일
- BigInt 직렬화 문제 해결 (`main.ts`에서 `toJSON` 설정)


### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- `lab.service.ts`의 검증 로직 순서가 적절한지
- 에러 코드 체계 (`LAB001`, `LAB002`, ...) 괜찮은지
- 트랜잭션 처리 방식


### 📚 참고 자료, 할 말
- 현재 `professorId`는 하드코딩 상태 (인증 기능 완성되면 `@CurrentUser()`로 교체 예정)
- 테스트: `http/lab.http` 파일로 WebStorm HTTP Client 테스트 가능