### PR TITLE
refactor: endpoint 네이밍 정리 및 에러 코드 통일 (#15)

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,11 +5,19 @@ import { AccessTokenGuard } from './guards/access-token.guard.js';
 import { RefreshTokenGuard } from './guards/refresh-token.guard.js';
 import { ApiLogin, ApiLogout, ApiRefresh } from './docs/auth.swagger.js';
 import { ApiTags } from '@nestjs/swagger';
+import { ApiRegister } from '../user/docs/user.swagger.js';
+import { RegisterRequestDto } from './dto/request/register.request.dto.js';
 
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
+
+  @Post('register')
+  @ApiRegister()
+  async register(@Body() dto: RegisterRequestDto) {
+    return this.authService.register(dto);
+  }
 
   @ApiLogin()
   @HttpCode(HttpStatus.OK)
@@ -27,7 +35,7 @@ export class AuthController {
 
   @ApiRefresh()
   @UseGuards(RefreshTokenGuard)
-  @Post('refresh-token')
+  @Post('refresh')
   async refreshToken(@Request() req: { user: { userId: number } }) {
     return this.authService.refreshToken(req.user.userId);
   }

--- a/src/auth/constants/auth.error.ts
+++ b/src/auth/constants/auth.error.ts
@@ -1,15 +1,11 @@
-import { ErrorInfo } from '../../common/exceptions/common.exception.js';
 import { HttpStatus } from '@nestjs/common';
+import { ErrorInfo } from '../../common/exceptions/common.exception.js';
 
 export const AUTH_ERROR: Record<string, ErrorInfo> = {
+  // 로그인
   USERNAME_OR_PHONE_REQUIRED: {
     code: 'USERNAME_OR_PHONE_REQUIRED',
     message: '아이디 또는 전화번호를 입력하세요',
-    status: HttpStatus.BAD_REQUEST,
-  },
-  PASSWORD_REQUIRED: {
-    code: 'PASSWORD_REQUIRED',
-    message: '비밀번호를 입력하세요',
     status: HttpStatus.BAD_REQUEST,
   },
   INVALID_CREDENTIALS: {
@@ -18,29 +14,32 @@ export const AUTH_ERROR: Record<string, ErrorInfo> = {
     status: HttpStatus.UNAUTHORIZED,
   },
 
-  ACCESS_TOKEN_EXPIRED: {
-    code: 'ACCESS_TOKEN_EXPIRED',
-    message: 'Access Token이 만료되었습니다',
-    status: HttpStatus.UNAUTHORIZED,
-  },
-  REFRESH_TOKEN_EXPIRED: {
-    code: 'REFRESH_TOKEN_EXPIRED',
-    message: 'Refresh Token이 만료되었습니다. 다시 로그인하세요',
-    status: HttpStatus.UNAUTHORIZED,
-  },
+  // Access Token
   ACCESS_TOKEN_MISSING: {
     code: 'ACCESS_TOKEN_MISSING',
     message: 'Access Token이 없습니다',
     status: HttpStatus.UNAUTHORIZED,
   },
-  REFRESH_TOKEN_MISSING: {
-    code: 'REFRESH_TOKEN_MISSING',
-    message: 'Refresh Token이 없습니다',
+  ACCESS_TOKEN_EXPIRED: {
+    code: 'ACCESS_TOKEN_EXPIRED',
+    message: 'Access Token이 만료되었습니다',
     status: HttpStatus.UNAUTHORIZED,
   },
   ACCESS_TOKEN_INVALID: {
     code: 'ACCESS_TOKEN_INVALID',
     message: '유효하지 않은 Access Token입니다',
+    status: HttpStatus.UNAUTHORIZED,
+  },
+
+  // Refresh Token
+  REFRESH_TOKEN_MISSING: {
+    code: 'REFRESH_TOKEN_MISSING',
+    message: 'Refresh Token이 없습니다',
+    status: HttpStatus.UNAUTHORIZED,
+  },
+  REFRESH_TOKEN_EXPIRED: {
+    code: 'REFRESH_TOKEN_EXPIRED',
+    message: 'Refresh Token이 만료되었습니다. 다시 로그인하세요',
     status: HttpStatus.UNAUTHORIZED,
   },
   REFRESH_TOKEN_INVALID: {
@@ -49,9 +48,27 @@ export const AUTH_ERROR: Record<string, ErrorInfo> = {
     status: HttpStatus.UNAUTHORIZED,
   },
 
+  // 회원가입
+  DUPLICATE_USERNAME: {
+    code: 'DUPLICATE_USERNAME',
+    message: '이미 사용 중인 아이디입니다',
+    status: HttpStatus.CONFLICT,
+  },
+  DUPLICATE_PHONE: {
+    code: 'DUPLICATE_PHONE',
+    message: '이미 사용 중인 전화번호입니다',
+    status: HttpStatus.CONFLICT,
+  },
+  DUPLICATE_EMAIL: {
+    code: 'DUPLICATE_EMAIL',
+    message: '이미 사용 중인 이메일입니다',
+    status: HttpStatus.CONFLICT,
+  },
+
+  // 공통
   USER_NOT_FOUND: {
     code: 'USER_NOT_FOUND',
     message: '사용자를 찾을 수 없습니다',
     status: HttpStatus.NOT_FOUND,
   },
-};
+} as const;

--- a/src/auth/dto/request/login.request.dto.ts
+++ b/src/auth/dto/request/login.request.dto.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, ValidateIf } from 'class-validator';
-import { AUTH_ERROR } from '../../constants/auth.error.js';
 
 export class LoginRequestDto {
   @ApiProperty({ example: 'newuser1', description: '아이디', required: false })
@@ -17,6 +16,6 @@ export class LoginRequestDto {
 
   @ApiProperty({ example: 'password123', description: '비밀번호' })
   @IsString()
-  @IsNotEmpty({ message: AUTH_ERROR.PASSWORD_REQUIRED.message })
+  @IsNotEmpty({ message: '비밀번호를 입력하세요' })
   password: string;
 }

--- a/src/auth/dto/request/register.request.dto.ts
+++ b/src/auth/dto/request/register.request.dto.ts
@@ -7,30 +7,29 @@ import {
   MinLength,
   ValidateIf,
 } from 'class-validator';
-import { USER_ERROR } from '../../constants/user.error.js';
 import { ApiProperty } from '@nestjs/swagger';
 
-export class CreateUserRequestDto {
+export class RegisterRequestDto {
   @ApiProperty({ example: 'newuser1', description: '아이디' })
   @IsString()
-  @IsNotEmpty({ message: USER_ERROR.USERNAME_REQUIRED.message })
+  @IsNotEmpty({ message: '아이디를 입력하세요' })
   username: string;
 
   @ApiProperty({ example: '01055556666', description: '전화번호 (010으로 시작, 11자리)' })
   @IsString()
-  @IsNotEmpty({ message: USER_ERROR.PHONE_REQUIRED.message })
-  @Matches(/^010[0-9]{8}$/, { message: USER_ERROR.PHONE_INVALID.message })
+  @IsNotEmpty({ message: '전화번호를 입력하세요' })
+  @Matches(/^010[0-9]{8}$/, { message: '올바른 전화번호 형식이 아닙니다' })
   phone: string;
 
   @ApiProperty({ example: 'password123', description: '비밀번호 (8자 이상)' })
   @IsString()
-  @IsNotEmpty({ message: USER_ERROR.PASSWORD_REQUIRED.message })
-  @MinLength(8, { message: USER_ERROR.PASSWORD_TOO_SHORT.message })
+  @IsNotEmpty({ message: '비밀번호를 입력하세요' })
+  @MinLength(8, { message: '비밀번호는 최소 8자 이상이어야 합니다' })
   password: string;
 
-  @ApiProperty({ example: '이교수', description: '이름' })
+  @ApiProperty({ example: '김철수', description: '이름' })
   @IsString()
-  @IsNotEmpty({ message: USER_ERROR.NAME_REQUIRED.message })
+  @IsNotEmpty({ message: '이름을 입력하세요' })
   name: string;
 
   @ApiProperty({
@@ -39,17 +38,17 @@ export class CreateUserRequestDto {
     description: '학위',
   })
   @IsString()
-  @IsNotEmpty({ message: USER_ERROR.DEGREE_REQUIRED.message })
+  @IsNotEmpty({ message: '학위를 선택하세요' })
   @IsEnum(['BACHELOR', 'MASTER', 'DOCTOR', 'PROFESSOR'])
   degree: string;
 
   @ApiProperty({
-    example: 'newprof@univ.ac.kr',
+    example: 'newprof@korea.ac.kr',
     required: false,
     description: '교수 이메일 (교수만 필수)',
   })
-  @ValidateIf((o: CreateUserRequestDto) => o.degree === 'PROFESSOR')
-  @IsNotEmpty({ message: USER_ERROR.EMAIL_REQUIRED.message })
-  @IsEmail({}, { message: USER_ERROR.EMAIL_INVALID.message })
+  @ValidateIf((o: RegisterRequestDto) => o.degree === 'PROFESSOR')
+  @IsNotEmpty({ message: '교수는 이메일을 입력하세요' })
+  @IsEmail({}, { message: '올바른 이메일 형식이 아닙니다' })
   professorEmail?: string;
 }

--- a/src/http/auth.http
+++ b/src/http/auth.http
@@ -1,3 +1,28 @@
+### 회원가입 - 학생
+POST http://localhost:8080/api/auth/register
+Content-Type: application/json
+
+{
+  "username": "student1",
+  "phone": "01012345678",
+  "password": "password123",
+  "name": "김학생",
+  "degree": "BACHELOR"
+}
+
+### 회원가입 - 교수
+POST http://localhost:8080/api/auth/register
+Content-Type: application/json
+
+{
+  "username": "prof1",
+  "phone": "01087654321",
+  "password": "password123",
+  "name": "박교수",
+  "degree": "PROFESSOR",
+  "professorEmail": "prof1@korea.ac.kr"
+}
+
 ### 로그인 (username)
 POST http://localhost:8080/api/auth/login
 Content-Type: application/json
@@ -26,7 +51,20 @@ Content-Type: application/json
   client.global.set("refreshToken", response.body.refreshToken);
 %}
 
-### 로그인 실패 - 비밀번호 틀림
+### 로그아웃
+POST http://localhost:8080/api/auth/logout
+Authorization: Bearer {{accessToken}}
+
+### 토큰 재발급
+POST http://localhost:8080/api/auth/refresh-token
+Authorization: Bearer {{refreshToken}}
+
+> {%
+  client.global.set("accessToken", response.body.accessToken);
+  client.global.set("refreshToken", response.body.refreshToken);
+%}
+
+### 에러 - 로그인 비밀번호 틀림
 POST http://localhost:8080/api/auth/login
 Content-Type: application/json
 
@@ -35,7 +73,7 @@ Content-Type: application/json
   "password": "wrongpassword"
 }
 
-### 로그인 실패 - 아이디/전화번호 없음
+### 에러 - 로그인 아이디/전화번호 없음
 POST http://localhost:8080/api/auth/login
 Content-Type: application/json
 
@@ -43,17 +81,5 @@ Content-Type: application/json
   "password": "password123"
 }
 
-### 로그아웃 (Access Token 필요)
-POST http://localhost:8080/api/auth/logout
-Authorization: Bearer {{accessToken}}
-
-### 토큰 재발급 (Refresh Token 필요)
-POST http://localhost:8080/api/auth/refresh-token
-Authorization: Bearer {{refreshToken}}
-
-> {%
-  client.global.set("accessToken", response.body.accessToken);
-%}
-
-### 토큰 재발급 실패 - 토큰 없음
+### 에러 - 토큰 재발급 토큰 없음
 POST http://localhost:8080/api/auth/refresh-token

--- a/src/http/user.http
+++ b/src/http/user.http
@@ -1,34 +1,9 @@
-### 회원가입 - 학생 (토큰 x)
-POST http://localhost:8080/api/users/register
-Content-Type: application/json
-
-{
-  "username": "student1",
-  "phone": "01012345678",
-  "password": "password123",
-  "name": "김학생",
-  "degree": "BACHELOR"
-}
-
-### 회원가입 - 교수 (토큰 x)
-POST http://localhost:8080/api/users/register
-Content-Type: application/json
-
-{
-  "username": "prof1",
-  "phone": "01087654321",
-  "password": "password123",
-  "name": "박교수",
-  "degree": "PROFESSOR",
-  "professorEmail": "prof1@univ.ac.kr"
-}
-
 ### 로그인 (토큰 저장)
 POST http://localhost:8080/api/auth/login
 Content-Type: application/json
 
 {
-  "username": "student1",
+  "username": "test1234",
   "password": "password123"
 }
 
@@ -37,11 +12,11 @@ Content-Type: application/json
   client.global.set("refreshToken", response.body.refreshToken);
 %}
 
-### 내 정보 조회 (토큰 o)
+### 내 정보 조회
 GET http://localhost:8080/api/users/me
 Authorization: Bearer {{accessToken}}
 
-### 내 정보 수정 (토큰 o)
+### 내 정보 수정
 PATCH http://localhost:8080/api/users/me
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
@@ -50,8 +25,8 @@ Content-Type: application/json
   "degree": "DOCTOR"
 }
 
-### 비밀번호 변경  (토큰 o)
-PATCH http://localhost:8080/api/users/me/change-password
+### 비밀번호 변경
+PATCH http://localhost:8080/api/users/me/password
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -60,8 +35,8 @@ Content-Type: application/json
   "newPassword": "newpassword123"
 }
 
-### 전화번호 변경 (토큰 o)
-PATCH http://localhost:8080/api/users/me/change-phone
+### 전화번호 변경
+PATCH http://localhost:8080/api/users/me/phone
 Authorization: Bearer {{accessToken}}
 Content-Type: application/json
 
@@ -69,18 +44,13 @@ Content-Type: application/json
   "phone": "01099998888"
 }
 
-### 회원 탈퇴 (토큰 o)
+### 회원 탈퇴
 DELETE http://localhost:8080/api/users/me
 Authorization: Bearer {{accessToken}}
 
-### [에러] 토큰 없이 조회 시도 - 401
+### 에러 - 토큰 없음
 GET http://localhost:8080/api/users/me
 
-### [에러] 만료된 토큰으로 조회 - 401
+### 에러 - 잘못된 토큰
 GET http://localhost:8080/api/users/me
 Authorization: Bearer invalid.token.here
-
-# 테스트 순서
-#1. 회원가입 실행
-#2. 로그인 실행 (토큰 자동 저장됨)
-#3. 내 정보 조회 등 실행 ({{accessToken}} 자동으로 들어감)

--- a/src/user/constants/user.error.ts
+++ b/src/user/constants/user.error.ts
@@ -2,77 +2,21 @@ import { HttpStatus } from '@nestjs/common';
 import { ErrorInfo } from '../../common/exceptions/common.exception.js';
 
 export const USER_ERROR: Record<string, ErrorInfo> = {
-  USERNAME_REQUIRED: {
-    code: 'USERNAME_REQUIRED',
-    message: '아이디를 입력하세요',
-    status: HttpStatus.BAD_REQUEST,
-  },
-  PHONE_REQUIRED: {
-    code: 'PHONE_REQUIRED',
-    message: '전화번호를 입력하세요',
-    status: HttpStatus.BAD_REQUEST,
-  },
-  PASSWORD_REQUIRED: {
-    code: 'PASSWORD_REQUIRED',
-    message: '비밀번호를 입력하세요',
-    status: HttpStatus.BAD_REQUEST,
-  },
-  NAME_REQUIRED: {
-    code: 'NAME_REQUIRED',
-    message: '이름을 입력하세요',
-    status: HttpStatus.BAD_REQUEST,
-  },
-  DEGREE_REQUIRED: {
-    code: 'DEGREE_REQUIRED',
-    message: '학위를 입력하세요',
-    status: HttpStatus.BAD_REQUEST,
-  },
-  EMAIL_REQUIRED: {
-    code: 'EMAIL_REQUIRED',
-    message: '교수는 이메일을 입력하세요',
-    status: HttpStatus.BAD_REQUEST,
-  },
-
-  PHONE_INVALID: {
-    code: 'PHONE_INVALID',
-    message: '올바른 전화번호 형식이 아닙니다',
-    status: HttpStatus.BAD_REQUEST,
-  },
-  EMAIL_INVALID: {
-    code: 'USER_EMAIL_INVALID',
-    message: '올바른 이메일 형식이 아닙니다',
-    status: HttpStatus.BAD_REQUEST,
-  },
-  PASSWORD_TOO_SHORT: {
-    code: 'PASSWORD_TOO_SHORT',
-    message: '비밀번호는 최소 8자 이상이어야 합니다',
-    status: HttpStatus.BAD_REQUEST,
-  },
-  IS_NOT_MATCHED_PASSWORD: {
-    code: 'IS_NOT_MATCHED_PASSWORD',
-    message: '비밀번호가 일치하지 않습니다',
-    status: HttpStatus.BAD_REQUEST,
-  },
-
-  DUPLICATE_EMAIL: {
-    code: 'DUPLICATE_EMAIL',
-    message: '이미 사용 중인 이메일입니다',
-    status: HttpStatus.CONFLICT,
-  },
-  DUPLICATE_USERNAME: {
-    code: 'DUPLICATE_USERNAME',
-    message: '이미 사용 중인 아이디입니다',
-    status: HttpStatus.CONFLICT,
-  },
-  DUPLICATE_PHONE: {
-    code: 'DUPLICATE_PHONE',
-    message: '이미 사용 중인 전화번호입니다',
-    status: HttpStatus.CONFLICT,
-  },
-
   NOT_FOUND: {
     code: 'USER_NOT_FOUND',
     message: '사용자를 찾을 수 없습니다',
     status: HttpStatus.NOT_FOUND,
+  },
+
+  PASSWORD_NOT_MATCHED: {
+    code: 'PASSWORD_NOT_MATCHED',
+    message: '현재 비밀번호가 일치하지 않습니다',
+    status: HttpStatus.BAD_REQUEST,
+  },
+
+  DUPLICATE_PHONE: {
+    code: 'DUPLICATE_PHONE',
+    message: '이미 사용 중인 전화번호입니다',
+    status: HttpStatus.CONFLICT,
   },
 } as const;

--- a/src/user/dto/request/change-password.request.dto.ts
+++ b/src/user/dto/request/change-password.request.dto.ts
@@ -1,16 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, MinLength } from 'class-validator';
-import { USER_ERROR } from '../../constants/user.error.js';
 
 export class ChangePasswordRequestDto {
   @ApiProperty({ example: 'password123', description: '현재 비밀번호' })
   @IsString()
-  @IsNotEmpty({ message: USER_ERROR.PASSWORD_REQUIRED.message })
+  @IsNotEmpty({ message: '현재 비밀번호를 입력하세요' })
   currentPassword: string;
 
   @ApiProperty({ example: 'newPassword123', description: '새 비밀번호 (8자 이상)' })
   @IsString()
-  @IsNotEmpty({ message: USER_ERROR.PASSWORD_REQUIRED.message })
-  @MinLength(8, { message: USER_ERROR.PASSWORD_TOO_SHORT.message })
+  @IsNotEmpty({ message: '새 비밀번호를 입력하세요' })
+  @MinLength(8, { message: '비밀번호는 최소 8자 이상이어야 합니다' })
   newPassword: string;
 }

--- a/src/user/dto/request/change-phone.request.dto.ts
+++ b/src/user/dto/request/change-phone.request.dto.ts
@@ -1,11 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, Matches } from 'class-validator';
-import { USER_ERROR } from '../../constants/user.error.js';
 
 export class ChangePhoneRequestDto {
   @ApiProperty({ example: '01099998888', description: '새 전화번호 (010으로 시작, 11자리)' })
   @IsString()
-  @IsNotEmpty({ message: USER_ERROR.PHONE_REQUIRED.message })
-  @Matches(/^010[0-9]{8}$/, { message: USER_ERROR.PHONE_INVALID.message })
+  @IsNotEmpty({ message: '새 전화번호를 입력하세요' })
+  @Matches(/^010[0-9]{8}$/, { message: '올바른 전화번호 형식이 아닙니다' })
   phone: string;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,7 +1,6 @@
-import { Body, Controller, Delete, Get, Patch, Post, Request, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Patch, Request, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { UserService } from './user.service.js';
-import { CreateUserRequestDto } from './dto/request/create-user.request.dto.js';
 import { UpdateUserRequestDto } from './dto/request/update-user.request.dto.js';
 import { ChangePasswordRequestDto } from './dto/request/change-password.request.dto.js';
 import { ChangePhoneRequestDto } from './dto/request/change-phone.request.dto.js';
@@ -11,7 +10,6 @@ import {
   ApiChangePhone,
   ApiDeleteUser,
   ApiGetProfile,
-  ApiRegister,
   ApiUpdateProfile,
 } from './docs/user.swagger.js';
 
@@ -20,12 +18,6 @@ import {
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
-  @Post('register')
-  @ApiRegister()
-  async register(@Body() dto: CreateUserRequestDto) {
-    return this.userService.register(dto);
-  }
-
   @UseGuards(AccessTokenGuard)
   @Get('me')
   @ApiGetProfile()
@@ -33,7 +25,6 @@ export class UserController {
     return this.userService.getProfile(req.user.userId);
   }
 
-  // 내 정보 수정
   @UseGuards(AccessTokenGuard)
   @Patch('me')
   @ApiUpdateProfile()
@@ -45,7 +36,14 @@ export class UserController {
   }
 
   @UseGuards(AccessTokenGuard)
-  @Patch('me/change-password')
+  @Delete('me')
+  @ApiDeleteUser()
+  async deleteUser(@Request() req: { user: { userId: number } }) {
+    return this.userService.deleteUser(req.user.userId);
+  }
+
+  @UseGuards(AccessTokenGuard)
+  @Patch('me/password')
   @ApiChangePassword()
   async changePassword(
     @Request() req: { user: { userId: number } },
@@ -55,19 +53,12 @@ export class UserController {
   }
 
   @UseGuards(AccessTokenGuard)
-  @Patch('me/change-phone')
+  @Patch('me/phone')
   @ApiChangePhone()
   async changePhone(
     @Request() req: { user: { userId: number } },
     @Body() dto: ChangePhoneRequestDto,
   ) {
     return this.userService.changePhone(req.user.userId, dto);
-  }
-
-  @UseGuards(AccessTokenGuard)
-  @Delete('me')
-  @ApiDeleteUser()
-  async deleteUser(@Request() req: { user: { userId: number } }) {
-    return this.userService.deleteUser(req.user.userId);
   }
 }


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #15

---

### 🚀 어떤 기능을 구현했나요?

- API 엔드포인트 네이밍 정리
- 에러 코드 통일

### 🔥 어떻게 해결했나요?

- POST /users/register → /auth/register 이동
- PATCH /me/change-password → /me/password
- PATCH /me/change-phone → /me/phone
- POST /auth/refresh-token → /auth/refresh
- auth.error.ts, user.error.ts 정리
- DTO 에러 메시지 직접 작성으로 변경

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?

- 엔드포인트 네이밍 컨벤션
- 에러 코드 분리 구조

### 📚 참고 자료, 할 말

- 기능 변경 없음