### PR TITLE
Feat/21 error code refactoring

### DIFF
--- a/src/http/lab.http
+++ b/src/http/lab.http
@@ -18,7 +18,7 @@ Content-Type: application/json
 Authorization: Bearer {{profToken}}
 
 {
-  "schoolName": "Test School",
+  "universityName": "Test university",
   "departmentName": "Test department",
   "labName": "Test Lab"
 }

--- a/src/lab/constants/lab.error.ts
+++ b/src/lab/constants/lab.error.ts
@@ -1,54 +1,69 @@
 import { HttpStatus } from '@nestjs/common';
 import { ErrorInfo } from '../../common/exceptions/common.exception.js';
 
+export const LAB_ERROR_CODES = {
+  USER_NOT_FOUND: 'L001',
+  USER_NOT_FOUND_IN_LAB: 'L002',
+  NOT_VERIFIED_PROFESSOR: 'L003',
+  ALREADY_IN_LAB: 'L004',
+  LAB_NOT_FOUND: 'L005',
+  FAILED_TO_CREATE_INVITE_CODE: 'L006',
+  PERMISSION_DENIED: 'L007',
+  CODE_NOT_FOUND: 'L008',
+  CODE_DEACTIVATED: 'L009',
+  CODE_EXPIRED: 'L010',
+} as const;
+
+export type LabErrorCode = (typeof LAB_ERROR_CODES)[keyof typeof LAB_ERROR_CODES];
+
 export const LAB_ERRORS: Record<string, ErrorInfo> = {
   USER_NOT_FOUND: {
-    code: 'USER_NOT_FOUND',
+    code: LAB_ERROR_CODES.USER_NOT_FOUND,
     message: '존재하지 않는 사용자.',
     status: HttpStatus.NOT_FOUND,
   },
   USER_NOT_FOUND_IN_LAB: {
-    code: 'USER_NOT_FOUND_IN_LAB',
+    code: LAB_ERROR_CODES.USER_NOT_FOUND_IN_LAB,
     message: '연구실에 존재하지 않는 사용자.',
     status: HttpStatus.NOT_FOUND,
   },
   NOT_VERIFIED_PROFESSOR: {
-    code: 'NOT_VERIFIED_PROFESSOR',
+    code: LAB_ERROR_CODES.NOT_VERIFIED_PROFESSOR,
     message: '인증되지 않은 교수.',
     status: HttpStatus.FORBIDDEN,
   },
   ALREADY_IN_LAB: {
-    code: 'ALREADY_IN_LAB',
+    code: LAB_ERROR_CODES.ALREADY_IN_LAB,
     message: '이미 연구실에 소속된 사용자.',
     status: HttpStatus.CONFLICT,
   },
   LAB_NOT_FOUND: {
-    code: 'LAB_NOT_FOUND',
+    code: LAB_ERROR_CODES.LAB_NOT_FOUND,
     message: '해당 연구실을 찾을 수 없습니다.',
     status: HttpStatus.NOT_FOUND,
   },
   FAILED_TO_CREATE_INVITE_CODE: {
-    code: 'FAILED_TO_CREATE_INVITE_CODE',
+    code: LAB_ERROR_CODES.FAILED_TO_CREATE_INVITE_CODE,
     message: '연구실 초대 코드 생성 실패.',
     status: HttpStatus.CONFLICT,
   },
   PERMISSION_DENIED: {
-    code: 'PERMISSION_DENIED',
+    code: LAB_ERROR_CODES.PERMISSION_DENIED,
     message: '권한이 없습니다.',
     status: HttpStatus.FORBIDDEN,
   },
   CODE_NOT_FOUND: {
-    code: 'CODE_NOT_FOUND',
+    code: LAB_ERROR_CODES.CODE_NOT_FOUND,
     message: '존재하지 않는 초대 코드.',
     status: HttpStatus.NOT_FOUND,
   },
   CODE_DEACTIVATED: {
-    code: 'CODE_DEACTIVATED',
+    code: LAB_ERROR_CODES.CODE_EXPIRED,
     message: '비활성화된 초대 코드.',
     status: HttpStatus.GONE,
   },
   CODE_EXPIRED: {
-    code: 'CODE_EXPIRED',
+    code: LAB_ERROR_CODES.CODE_EXPIRED,
     message: '만료된 초대 코드.',
     status: HttpStatus.GONE,
   },

--- a/src/lab/docs/lab.swagger.ts
+++ b/src/lab/docs/lab.swagger.ts
@@ -5,6 +5,7 @@ import { InviteCodeResponseDto } from '../dto/response/invite-code.response.dto.
 import { ValidateInviteCodeResponseDto } from '../dto/response/validate-invite-code.response.dto.js';
 import { JoinLabResponseDto } from '../dto/response/join-lab.response.dto.js';
 import { CreateInviteCodeRequestDto } from '../dto/request/create-invite-code.request.dto.js';
+import { JoinLabRequestDto } from '../dto/request/join-lab.request.dto.js';
 
 export function ApiCreateLab() {
   return applyDecorators(
@@ -83,7 +84,7 @@ export function ApiJoinLab() {
       summary: '연구실 참여',
     }),
     ApiBody({
-      type: JoinLabResponseDto,
+      type: JoinLabRequestDto,
       description: '8자리 초대 코드',
     }),
     ApiResponse({ status: 201, description: '연구실 참여 성공', type: JoinLabResponseDto }),

--- a/src/lab/dto/request/create-lab.request.dto.ts
+++ b/src/lab/dto/request/create-lab.request.dto.ts
@@ -2,10 +2,10 @@ import { IsString, MinLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateLabRequestDto {
-  @ApiProperty({ example: 'My School', description: '학교 이름' })
+  @ApiProperty({ example: 'My University', description: '학교 이름' })
   @IsString()
   @MinLength(2, { message: '학교 이름은 최소 2자 이상이어야 합니다.' })
-  schoolName: string;
+  universityName: string;
 
   @ApiProperty({ example: 'My Department', description: '학과 이름' })
   @IsString()

--- a/src/lab/dto/response/create-lab.response.dto.ts
+++ b/src/lab/dto/response/create-lab.response.dto.ts
@@ -7,7 +7,7 @@ export class CreateLabResponseDto {
   @ApiProperty({ example: 'My Lab', description: '연구실 이름' })
   labName: string;
 
-  @ApiProperty({ example: 'My School', description: '연구실 소속 학교' })
+  @ApiProperty({ example: 'My university', description: '연구실 소속 학교' })
   universityName: string;
 
   @ApiProperty({ example: 'My Department', description: '연구실 소속 학과' })

--- a/src/lab/dto/response/join-lab.response.dto.ts
+++ b/src/lab/dto/response/join-lab.response.dto.ts
@@ -7,9 +7,6 @@ export class JoinLabResponseDto {
   @ApiProperty({ example: 'My Lab', description: '연구실 이름' })
   labName: string;
 
-  @ApiProperty({ example: 1, description: '사용자 ID' })
-  userId: number;
-
   @ApiProperty({ example: 'MEMBER', description: '연구실 내 역할 (PROFESSOR, LAB_LEADER, MEMBER)' })
   role: string;
 }

--- a/src/lab/dto/response/validate-invite-code.response.dto.ts
+++ b/src/lab/dto/response/validate-invite-code.response.dto.ts
@@ -7,7 +7,7 @@ export class ValidateInviteCodeResponseDto {
   @ApiPropertyOptional({ example: 'My Lab', description: '연구실 이름' })
   labName?: string;
 
-  @ApiPropertyOptional({ example: 'My School', description: '학교 이름' })
+  @ApiPropertyOptional({ example: 'My university', description: '학교 이름' })
   universityName?: string;
 
   @ApiPropertyOptional({ example: 'My Department', description: '학과 이름' })

--- a/src/lab/lab.controller.ts
+++ b/src/lab/lab.controller.ts
@@ -63,7 +63,7 @@ export class LabController {
     @Request() req: { user: { userId: number } },
     @Param('labId', ParseIntPipe) labId: number,
     @Param('code') code: string,
-  ): Promise<void> {
+  ): Promise<{ message: string }> {
     return this.labService.revokeInviteCode(labId, code, req.user.userId);
   }
 

--- a/src/lab/lab.controller.ts
+++ b/src/lab/lab.controller.ts
@@ -35,7 +35,7 @@ export class LabController {
   constructor(private readonly labService: LabService) {}
 
   @UseGuards(AccessTokenGuard)
-  @Post()
+  @Post('create')
   @ApiCreateLab()
   async createLab(
     @Request() req: { user: { userId: number } },

--- a/src/lab/lab.controller.ts
+++ b/src/lab/lab.controller.ts
@@ -56,7 +56,7 @@ export class LabController {
   }
 
   @UseGuards(AccessTokenGuard)
-  @Delete(':labId/invite-codes/:code')
+  @Delete(':labId/revoke-invite-codes/:code')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiRevokeInviteCode()
   async revokeInviteCode(

--- a/src/lab/lab.controller.ts
+++ b/src/lab/lab.controller.ts
@@ -74,7 +74,7 @@ export class LabController {
   }
 
   @UseGuards(AccessTokenGuard)
-  @Post('invite-codes')
+  @Post('join')
   @ApiJoinLab()
   async joinLab(
     @Request() req: { user: { userId: number } },

--- a/src/lab/lab.service.ts
+++ b/src/lab/lab.service.ts
@@ -110,7 +110,11 @@ export class LabService {
   }
 
   // 초대 코드 비활성화 요청
-  async revokeInviteCode(labId: number, code: string, userId: number): Promise<void> {
+  async revokeInviteCode(
+    labId: number,
+    code: string,
+    userId: number,
+  ): Promise<{ message: string }> {
     await this.chkLabExist(labId);
     await this.chkUserPermission(userId, labId);
 
@@ -125,6 +129,8 @@ export class LabService {
     if (result.count === 0) {
       throw new CommonException(LAB_ERRORS.CODE_NOT_FOUND);
     }
+
+    return { message: '초대 코드 삭제가 완료되었습니다' };
   }
 
   // 초대 코드 검증 요청

--- a/src/lab/lab.service.ts
+++ b/src/lab/lab.service.ts
@@ -27,7 +27,7 @@ export class LabService {
       const lab = await tx.labs.create({
         data: {
           name: dto.labName,
-          university_name: dto.schoolName,
+          university_name: dto.universityName,
           department_name: dto.departmentName,
           professor_id: professorId,
         },

--- a/src/lab/lab.service.ts
+++ b/src/lab/lab.service.ts
@@ -8,7 +8,7 @@ import { CreateLabResponseDto } from './dto/response/create-lab.response.dto.js'
 import { InviteCodeResponseDto } from './dto/response/invite-code.response.dto.js';
 import { ValidateInviteCodeResponseDto } from './dto/response/validate-invite-code.response.dto.js';
 import { randomUUID } from 'node:crypto';
-import { invite_codes, Prisma } from '../../generated/prisma/client.js';
+import { invite_codes, Prisma } from '@prisma/client';
 import { JoinLabRequestDto } from './dto/request/join-lab.request.dto.js';
 import { JoinLabResponseDto } from './dto/response/join-lab.response.dto.js';
 
@@ -196,7 +196,6 @@ export class LabService {
       return {
         labId: Number(inviteCode.lab_id),
         labName: inviteCode.labs.name,
-        userId: userId,
         role: membership.role,
       };
     });


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #21 

---

### 🚀 어떤 기능을 구현했나요?
- DB에 맞는 변수명 통일
- api 엔드포인트 수정
- swagger 간결화
- Lab 모듈의 에러 코드를 숫자 기반 코드(L001~L010)로 변경


### 🔥 어떻게 해결했나요?
- school -> university 변수명 변경
- create lab, revoke invite code api 수정
- `LAB_ERROR_CODES` 상수 객체를 const assertion으로 정의
- `LAB_ERRORS` 객체의 각 에러 항목에서 `LAB_ERROR_CODES` 참조하도록 수정
- API 응답의 `code` 필드가 'USER_NOT_FOUND' 대신 'L001' 형식으로 반환되도록 개선


### 📚 참고 자료, 할 말
- const assertion 방식을 채택하여 타입 안전성을 유지하면서도 간결한 코드 구조 구현