### PR TITLE
feat: 연구실 멤버 조회 API 추가

### DIFF
--- a/src/lab/docs/lab.swagger.ts
+++ b/src/lab/docs/lab.swagger.ts
@@ -6,6 +6,7 @@ import { ValidateInviteCodeResponseDto } from '../dto/response/validate-invite-c
 import { JoinLabResponseDto } from '../dto/response/join-lab.response.dto.js';
 import { CreateInviteCodeRequestDto } from '../dto/request/create-invite-code.request.dto.js';
 import { JoinLabRequestDto } from '../dto/request/join-lab.request.dto.js';
+import { GetMembersResponseDto } from '../dto/response/get-members.dto.js';
 
 export function ApiCreateLab() {
   return applyDecorators(
@@ -92,5 +93,17 @@ export function ApiJoinLab() {
     ApiResponse({ status: 404, description: '존재하지 않는 초대 코드' }),
     ApiResponse({ status: 409, description: '이미 연구실에 소속된 사용자' }),
     ApiResponse({ status: 410, description: '만료된 초대 코드 / 비활성화된 초대 코드' }),
+  );
+}
+
+export function ApiGetMembers() {
+  return applyDecorators(
+    ApiBearerAuth(),
+    ApiOperation({
+      summary: '연구실 멤버 조회',
+    }),
+    ApiParam({ name: 'labId', description: '연구실 ID', type: Number }),
+    ApiResponse({ status: 200, description: '조회 성공', type: [GetMembersResponseDto] }),
+    ApiResponse({ status: 404, description: '존재하지 않는 연구실' }),
   );
 }

--- a/src/lab/dto/response/get-members.dto.ts
+++ b/src/lab/dto/response/get-members.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Degree } from '@prisma/client';
+
+export class GetMembersResponseDto {
+  @ApiProperty({ example: '홍길동', description: '멤버 이름' })
+  name: string;
+
+  @ApiProperty({ example: 'MASTER', enum: ['BACHELOR', 'MASTER', 'DOCTOR', 'PROFESSOR'] })
+  degree: Degree;
+
+  @ApiProperty({ example: 'MEMBER', description: '역할' })
+  role: string;
+}

--- a/src/lab/lab.controller.ts
+++ b/src/lab/lab.controller.ts
@@ -24,10 +24,12 @@ import {
   ApiCreateLab,
   ApiJoinLab,
   ApiRevokeInviteCode,
+  ApiGetMembers,
 } from './docs/lab.swagger.js';
 import { ValidateInviteCodeResponseDto } from './dto/response/validate-invite-code.response.dto.js';
 import { JoinLabRequestDto } from './dto/request/join-lab.request.dto.js';
 import { JoinLabResponseDto } from './dto/response/join-lab.response.dto.js';
+import { GetMembersResponseDto } from './dto/response/get-members.dto.js';
 
 @ApiTags('Labs')
 @Controller('labs')
@@ -81,5 +83,11 @@ export class LabController {
     @Body() dto: JoinLabRequestDto,
   ): Promise<JoinLabResponseDto> {
     return this.labService.joinLab(req.user.userId, dto);
+  }
+
+  @Get(':labId/members')
+  @ApiGetMembers()
+  async getMembers(@Param('labId', ParseIntPipe) labId: number): Promise<GetMembersResponseDto[]> {
+    return this.labService.getMembers(labId);
   }
 }

--- a/src/lab/lab.service.ts
+++ b/src/lab/lab.service.ts
@@ -11,6 +11,7 @@ import { randomUUID } from 'node:crypto';
 import { invite_codes, Prisma } from '@prisma/client';
 import { JoinLabRequestDto } from './dto/request/join-lab.request.dto.js';
 import { JoinLabResponseDto } from './dto/response/join-lab.response.dto.js';
+import { GetMembersResponseDto } from './dto/response/get-members.dto.js';
 
 type PrismaClient = PrismaService | Prisma.TransactionClient;
 
@@ -199,6 +200,27 @@ export class LabService {
         role: membership.role,
       };
     });
+  }
+
+  // 연구실 멤버 조회
+  async getMembers(labId: number): Promise<GetMembersResponseDto[]> {
+    const members = await this.prisma.lab_members.findMany({
+      where: { lab_id: BigInt(labId), left_at: null },
+      include: {
+        users: {
+          select: {
+            name: true,
+            degree: true,
+          },
+        },
+      },
+    });
+
+    return members.map((member) => ({
+      name: member.users.name,
+      degree: member.users.degree,
+      role: member.role,
+    }));
   }
 
   /* ##### 내장 함수 ##### */


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #33

---

### 🚀 어떤 기능을 구현했나요?
- 연구실 멤버 목록 조회 API (GET `/labs/:labId/members`)

### 🔥 어떻게 해결했나요?
- prisma `findMany` + `include`로 `lab_members`, `users` 조인 조회
- `left_at`이 `null`인 활동 중 멤버만 필터링

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 해당 연구실 멤버만 조회 가능하도록 권한 체크 필요한지
- 더 필요한 리턴 값 ??

### 📚 참고 자료, 할 말
-
