### PR TITLE
Feat/change degree

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,7 +55,7 @@ model lab_members {
   id                    BigInt                  @id @default(autoincrement())
   user_id               BigInt
   lab_id                BigInt
-  role                  String                  @default("MEMBER")
+  role                  Role                    @default(MEMBER)
   joined_at             DateTime                @default(now()) @db.Timestamptz(6)
   left_at               DateTime?               @db.Timestamptz(6)
   labs                  labs                    @relation(fields: [lab_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
@@ -315,4 +315,11 @@ enum Degree {
 enum TokenType {
   EMAIL_VERIFY
   PASSWORD_RESET
+}
+
+enum Role {
+  PROFESSOR
+  LAB_LEADER
+  SUB_LEADER
+  MEMBER
 }

--- a/src/lab/constants/lab.error.ts
+++ b/src/lab/constants/lab.error.ts
@@ -12,6 +12,10 @@ export const LAB_ERROR_CODES = {
   CODE_NOT_FOUND: 'L008',
   CODE_DEACTIVATED: 'L009',
   CODE_EXPIRED: 'L010',
+
+  NO_PERMISSION_TO_CHANGE_ROLE: 'L101',
+  MAX_LAB_LEADER_EXCEEDED: 'L102',
+  MAX_SUB_LEADER_EXCEEDED: 'L103',
 } as const;
 
 export type LabErrorCode = (typeof LAB_ERROR_CODES)[keyof typeof LAB_ERROR_CODES];
@@ -58,7 +62,7 @@ export const LAB_ERRORS: Record<string, ErrorInfo> = {
     status: HttpStatus.NOT_FOUND,
   },
   CODE_DEACTIVATED: {
-    code: LAB_ERROR_CODES.CODE_EXPIRED,
+    code: LAB_ERROR_CODES.CODE_DEACTIVATED,
     message: '비활성화된 초대 코드.',
     status: HttpStatus.GONE,
   },
@@ -66,5 +70,25 @@ export const LAB_ERRORS: Record<string, ErrorInfo> = {
     code: LAB_ERROR_CODES.CODE_EXPIRED,
     message: '만료된 초대 코드.',
     status: HttpStatus.GONE,
+  },
+};
+
+export const CHANGE_ROLE_ERROR: Record<string, ErrorInfo> = {
+  NO_PERMISSION: {
+    code: 'L101',
+    message: '권한이 없습니다.',
+    status: HttpStatus.FORBIDDEN,
+  },
+
+  MAX_LAB_LEADER_EXCEEDED: {
+    code: 'L102',
+    message: '랩장은 1명까지 가능합니다.',
+    status: HttpStatus.CONFLICT,
+  },
+
+  MAX_SUB_LEADER_EXCEEDED: {
+    code: 'L103',
+    message: '부랩장은 2명까지 가능합니다.',
+    status: HttpStatus.CONFLICT,
   },
 };

--- a/src/lab/docs/lab.swagger.ts
+++ b/src/lab/docs/lab.swagger.ts
@@ -7,6 +7,7 @@ import { JoinLabResponseDto } from '../dto/response/join-lab.response.dto.js';
 import { CreateInviteCodeRequestDto } from '../dto/request/create-invite-code.request.dto.js';
 import { JoinLabRequestDto } from '../dto/request/join-lab.request.dto.js';
 import { GetMembersResponseDto } from '../dto/response/get-members.dto.js';
+import { ChangeRoleRequestDto } from '../dto/request/change-role.request.dto.js';
 
 export function ApiCreateLab() {
   return applyDecorators(
@@ -105,5 +106,24 @@ export function ApiGetMembers() {
     ApiParam({ name: 'labId', description: '연구실 ID', type: Number }),
     ApiResponse({ status: 200, description: '조회 성공', type: [GetMembersResponseDto] }),
     ApiResponse({ status: 404, description: '존재하지 않는 연구실' }),
+  );
+}
+
+export function ApiChangeRole() {
+  return applyDecorators(
+    ApiBearerAuth(),
+    ApiOperation({
+      summary: '멤버 역할 변경',
+      description:
+        '교수는 랩장/부랩장 임명 및 해임 가능. 랩장은 부랩장 임명 및 해임 가능. 랩장 1명, 부랩장 2명 제한.',
+    }),
+    ApiParam({ name: 'labId', description: '연구실 ID', type: Number }),
+    ApiParam({ name: 'userId', description: '역할을 변경할 멤버 ID', type: Number }),
+    ApiBody({ type: ChangeRoleRequestDto }),
+    ApiResponse({ status: 200, description: '역할 변경 성공' }),
+    ApiResponse({ status: 401, description: '인증 실패' }),
+    ApiResponse({ status: 403, description: '권한 없음 (교수/랩장만 가능)' }),
+    ApiResponse({ status: 404, description: '존재하지 않는 사용자' }),
+    ApiResponse({ status: 409, description: '랩장 1명 초과 / 부랩장 2명 초과' }),
   );
 }

--- a/src/lab/dto/request/change-role.request.dto.ts
+++ b/src/lab/dto/request/change-role.request.dto.ts
@@ -1,0 +1,8 @@
+import { IsEnum, IsNotEmpty } from 'class-validator';
+import { Role } from '@prisma/client';
+
+export class ChangeRoleRequestDto {
+  @IsNotEmpty()
+  @IsEnum(Role, { message: '유효하지 않은 역할입니다' })
+  role: Role;
+}

--- a/src/lab/lab.controller.ts
+++ b/src/lab/lab.controller.ts
@@ -10,6 +10,7 @@ import {
   HttpStatus,
   HttpCode,
   Get,
+  Patch,
 } from '@nestjs/common';
 import { LabService } from './lab.service.js';
 import { CreateLabRequestDto } from './dto/request/create-lab.request.dto.js';
@@ -25,11 +26,13 @@ import {
   ApiJoinLab,
   ApiRevokeInviteCode,
   ApiGetMembers,
+  ApiChangeRole,
 } from './docs/lab.swagger.js';
 import { ValidateInviteCodeResponseDto } from './dto/response/validate-invite-code.response.dto.js';
 import { JoinLabRequestDto } from './dto/request/join-lab.request.dto.js';
 import { JoinLabResponseDto } from './dto/response/join-lab.response.dto.js';
 import { GetMembersResponseDto } from './dto/response/get-members.dto.js';
+import { ChangeRoleRequestDto } from './dto/request/change-role.request.dto.js';
 
 @ApiTags('Labs')
 @Controller('labs')
@@ -89,5 +92,17 @@ export class LabController {
   @ApiGetMembers()
   async getMembers(@Param('labId', ParseIntPipe) labId: number): Promise<GetMembersResponseDto[]> {
     return this.labService.getMembers(labId);
+  }
+
+  @UseGuards(AccessTokenGuard)
+  @Patch(':labId/members/:userId/change-role')
+  @ApiChangeRole()
+  async changeRole(
+    @Param('labId', ParseIntPipe) labId: number,
+    @Param('userId', ParseIntPipe) targetUserId: number,
+    @Request() req: { user: { userId: number } },
+    @Body() dto: ChangeRoleRequestDto,
+  ): Promise<void> {
+    return this.labService.changeRole(labId, targetUserId, req.user.userId, dto);
   }
 }

--- a/src/lab/lab.service.ts
+++ b/src/lab/lab.service.ts
@@ -1,17 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { CommonException } from '../common/exceptions/common.exception.js';
-import { LAB_ERRORS } from './constants/lab.error.js';
+import { CHANGE_ROLE_ERROR, LAB_ERRORS } from './constants/lab.error.js';
 import { CreateLabRequestDto } from './dto/request/create-lab.request.dto.js';
 import { CreateInviteCodeRequestDto } from './dto/request/create-invite-code.request.dto.js';
 import { CreateLabResponseDto } from './dto/response/create-lab.response.dto.js';
 import { InviteCodeResponseDto } from './dto/response/invite-code.response.dto.js';
 import { ValidateInviteCodeResponseDto } from './dto/response/validate-invite-code.response.dto.js';
 import { randomUUID } from 'node:crypto';
-import { invite_codes, Prisma } from '@prisma/client';
+import { invite_codes, Prisma, Role, Degree } from '@prisma/client';
 import { JoinLabRequestDto } from './dto/request/join-lab.request.dto.js';
 import { JoinLabResponseDto } from './dto/response/join-lab.response.dto.js';
 import { GetMembersResponseDto } from './dto/response/get-members.dto.js';
+import { ChangeRoleRequestDto } from './dto/request/change-role.request.dto.js';
+import { USER_ERROR } from '../user/constants/user.error.js';
 
 type PrismaClient = PrismaService | Prisma.TransactionClient;
 
@@ -38,7 +40,7 @@ export class LabService {
         data: {
           user_id: professorId,
           lab_id: lab.id,
-          role: 'PROFESSOR',
+          role: Role.PROFESSOR,
         },
       });
 
@@ -223,6 +225,66 @@ export class LabService {
     }));
   }
 
+  async changeRole(
+    labId: number,
+    targetUserId: number,
+    userId: number,
+    dto: ChangeRoleRequestDto,
+  ): Promise<void> {
+    const user = await this.prisma.lab_members.findFirst({
+      where: { user_id: BigInt(userId), lab_id: BigInt(labId) },
+    });
+    if (!user) throw new CommonException(USER_ERROR.NOT_FOUND);
+    if (user.role !== Role.PROFESSOR && user.role !== Role.LAB_LEADER)
+      throw new CommonException(CHANGE_ROLE_ERROR.NO_PERMISSION);
+
+    const targetUser = await this.prisma.lab_members.findFirst({
+      where: { user_id: BigInt(targetUserId), lab_id: user.lab_id },
+    });
+    if (!targetUser) throw new CommonException(USER_ERROR.NOT_FOUND);
+    if (targetUser.role === dto.role) return;
+    if (targetUser.role === Role.PROFESSOR)
+      throw new CommonException(CHANGE_ROLE_ERROR.NO_PERMISSION);
+
+    const labLeaderCount = await this.prisma.lab_members.count({
+      where: { lab_id: BigInt(labId), role: Role.LAB_LEADER },
+    });
+
+    const subLeaderCount = await this.prisma.lab_members.count({
+      where: { lab_id: BigInt(labId), role: Role.SUB_LEADER },
+    });
+
+    switch (user.role) {
+      case Role.PROFESSOR:
+        if (dto.role === Role.LAB_LEADER) {
+          if (labLeaderCount > 0)
+            throw new CommonException(CHANGE_ROLE_ERROR.MAX_LAB_LEADER_EXCEEDED);
+        } else if (dto.role === Role.SUB_LEADER) {
+          if (subLeaderCount > 1)
+            throw new CommonException(CHANGE_ROLE_ERROR.MAX_SUB_LEADER_EXCEEDED);
+        }
+
+        break;
+      case Role.LAB_LEADER:
+        if (targetUser.role === Role.LAB_LEADER)
+          throw new CommonException(CHANGE_ROLE_ERROR.NO_PERMISSION);
+
+        if (dto.role === Role.LAB_LEADER)
+          throw new CommonException(CHANGE_ROLE_ERROR.NO_PERMISSION);
+        else if (dto.role === Role.SUB_LEADER)
+          if (subLeaderCount > 1)
+            throw new CommonException(CHANGE_ROLE_ERROR.MAX_SUB_LEADER_EXCEEDED);
+
+        break;
+    }
+
+    await this.prisma.lab_members.update({
+      where: {
+        user_id_lab_id: { user_id: BigInt(targetUserId), lab_id: BigInt(labId) },
+      },
+      data: { role: dto.role },
+    });
+  }
   /* ##### 내장 함수 ##### */
 
   // 교수 인증 확인
@@ -239,7 +301,7 @@ export class LabService {
       throw new CommonException(LAB_ERRORS.NOT_VERIFIED_PROFESSOR);
     }
 
-    if (user.degree !== 'PROFESSOR') {
+    if (user.degree !== Degree.PROFESSOR) {
       throw new CommonException(LAB_ERRORS.PERMISSION_DENIED);
     }
   }
@@ -269,7 +331,7 @@ export class LabService {
       throw new CommonException(LAB_ERRORS.USER_NOT_FOUND_IN_LAB);
     }
 
-    if (chkMember.role !== 'PROFESSOR' && chkMember.role !== 'LAB_LEADER') {
+    if (chkMember.role !== Role.PROFESSOR && chkMember.role !== Role.LAB_LEADER) {
       throw new CommonException(LAB_ERRORS.PERMISSION_DENIED);
     }
   }


### PR DESCRIPTION
---

### 🚀 어떤 기능을 구현했나요?
- 연구실 멤버의 역할 변경 API 추가
- `Role` enum(PROFESSOR/LAB_LEADER/SUB_LEADER/MEMBER) 생성

### 🔥 어떻게 해결했나요?
- `PATCH /labs/:labId/members/:userId/change-role` 엔드포인트 구현
- 권한별 변경 가능 범위 분리
  - 교수: 랩장/부랩장 임명 및 해임 가능
  - 랩장: 부랩장 임명 및 해임 가능
- 랩장 1명, 부랩장 2명 초과 시 예외 처리
- 역할 값을 문자열 리터럴 대신 Prisma `Role`/`Degree` enum으로 처리

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- `LabService.changeRole`의 권한 분기 로직 (`src/lab/lab.service.ts`) — 교수/랩장 케이스별 예외 조건이 요구사항과 맞는지
- 랩장 1명/부랩장 2명 제한 체크가 동시성 상황에서도 안전한지

### 📚 참고 자료, 할 말
- 역할 변경 요구사항: 교수 → 랩장/부랩장 임명·해임 / 랩장 → 부랩장만 임명·해임 / 랩장 1명, 부랩장 2명 제한